### PR TITLE
Return events in reversed order by default

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -136,7 +136,7 @@ func (c *Command) Exec(ctx context.Context, args []string) {
 
 	profile, err := c.actions.ProfileGet(ctx)
 	if err != nil {
-		c.handler.OnResult(ctx, actions.ErrorResult{errors.Unauthorized()})
+		c.handler.OnResult(ctx, actions.ErrorResult{err})
 		return
 	}
 

--- a/internal/database/events.go
+++ b/internal/database/events.go
@@ -72,9 +72,9 @@ func (db *DB) EventsListByPayloadID(payloadID int64, opts ...EventsListOption) (
 	var order string
 
 	if options.Reverse {
-		order = "DESC"
-	} else {
 		order = "ASC"
+	} else {
+		order = "DESC"
 	}
 
 	query, params = paginate(


### PR DESCRIPTION
It is better to retrurn last events by default