### PR TITLE
Added support for NS records

### DIFF
--- a/internal/database/dns_records_test.go
+++ b/internal/database/dns_records_test.go
@@ -134,7 +134,7 @@ func TestDNSRecordsGetCountByPayloadID(t *testing.T) {
 
 	res, err = db.DNSRecordsGetCountByPayloadID(2)
 	assert.NoError(t, err)
-	assert.EqualValues(t, 1, res)
+	assert.EqualValues(t, 2, res)
 }
 
 func TestDNSRecordsGetByPayloadIDAndIndex(t *testing.T) {

--- a/internal/database/fixtures/dns_records.yml
+++ b/internal/database/fixtures/dns_records.yml
@@ -99,8 +99,8 @@
   created_at: RAW=NOW() AT TIME ZONE 'UTC'
 
 - id: 11
-  payload_id: 1
-  index: 10
+  payload_id: 2
+  index: 2
   name: test-ns
   type: NS
   ttl: 60

--- a/internal/database/fixtures/dns_records.yml
+++ b/internal/database/fixtures/dns_records.yml
@@ -97,3 +97,13 @@
   values: '{1.1.1.1}'
   strategy: all
   created_at: RAW=NOW() AT TIME ZONE 'UTC'
+
+- id: 11
+  payload_id: 1
+  index: 10
+  name: test-ns
+  type: NS
+  ttl: 60
+  values: '{ns1.example.com.}'
+  strategy: all
+  created_at: RAW=NOW() AT TIME ZONE 'UTC'

--- a/internal/database/migrations/000019_add_ns_record_type.down.sql
+++ b/internal/database/migrations/000019_add_ns_record_type.down.sql
@@ -1,0 +1,6 @@
+DELETE FROM dns_records WHERE type = 'NS'::dns_record_type;
+ALTER TABLE dns_records ALTER type TYPE text;
+ALTER TYPE dns_record_type RENAME TO dns_record_type_old;
+CREATE TYPE dns_record_type AS ENUM('A', 'AAAA', 'MX', 'TXT', 'CNAME');
+ALTER TABLE dns_records ALTER type TYPE dns_record_type USING type::dns_record_type;
+DROP TYPE dns_record_type_old;

--- a/internal/database/migrations/000019_add_ns_record_type.up.sql
+++ b/internal/database/migrations/000019_add_ns_record_type.up.sql
@@ -1,0 +1,1 @@
+ALTER TYPE dns_record_type ADD VALUE 'NS';

--- a/internal/database/models/dns_record.go
+++ b/internal/database/models/dns_record.go
@@ -13,6 +13,7 @@ const (
 	DNSTypeMX    = "MX"
 	DNSTypeTXT   = "TXT"
 	DNSTypeCNAME = "CNAME"
+	DNSTypeNS    = "NS"
 )
 
 var DNSTypesAll = []string{
@@ -21,6 +22,7 @@ var DNSTypesAll = []string{
 	DNSTypeMX,
 	DNSTypeTXT,
 	DNSTypeCNAME,
+	DNSTypeNS,
 }
 
 const (
@@ -61,6 +63,8 @@ func (r *DNSRecord) Qtype() uint16 {
 		return dns.TypeTXT
 	case DNSTypeCNAME:
 		return dns.TypeCNAME
+	case DNSTypeNS:
+		return dns.TypeNS
 	}
 	panic("unsupported dns query type")
 }

--- a/internal/dnsdb/dnsdb_test.go
+++ b/internal/dnsdb/dnsdb_test.go
@@ -95,6 +95,12 @@ var tests = []struct {
 	{"test2.test-wildcard.c1da9f3d.sonar.test.", dns.TypeA, [][]string{
 		{"192.168.1.1"},
 	}},
+	{"test2.test-wildcard.c1da9f3d.sonar.test.", dns.TypeA, [][]string{
+		{"192.168.1.1"},
+	}},
+	{"test-ns.c1da9f3d.sonar.test.", dns.TypeNS, [][]string{
+		{"ns1.example.com."},
+	}},
 
 	// Strategies
 	{"test-all.c1da9f3d.sonar.test.", dns.TypeA, [][]string{

--- a/internal/dnsdb/dnsdb_test.go
+++ b/internal/dnsdb/dnsdb_test.go
@@ -98,7 +98,7 @@ var tests = []struct {
 	{"test2.test-wildcard.c1da9f3d.sonar.test.", dns.TypeA, [][]string{
 		{"192.168.1.1"},
 	}},
-	{"test-ns.c1da9f3d.sonar.test.", dns.TypeNS, [][]string{
+	{"test-ns.6564e0c7.sonar.test.", dns.TypeNS, [][]string{
 		{"ns1.example.com."},
 	}},
 

--- a/pkg/dnsx/dnsx_test.go
+++ b/pkg/dnsx/dnsx_test.go
@@ -64,6 +64,7 @@ func TestMain(m *testing.M) {
 				dnsx.NewRR("*.sonar.test.", dns.TypeAAAA, 10, "1.1.1.1"),
 				dnsx.NewRR("*.sonar.test.", dns.TypeMX, 10, "10 mx.sonar.test."),
 				dnsx.NewRR("c1da9f3d.sonar.test.", dns.TypeA, 10, "2.2.2.2"),
+				dnsx.NewRR("ns.sonar.test.", dns.TypeNS, 10, "ns1.example.com."),
 			})),
 		),
 	)
@@ -104,6 +105,9 @@ var tests = []struct {
 	}},
 	{"c1da9f3d.sonar.test.", dns.TypeA, [][]string{
 		{"2.2.2.2"},
+	}},
+	{"ns.sonar.test.", dns.TypeNS, [][]string{
+		{"ns1.example.com."},
 	}},
 }
 

--- a/pkg/dnsx/utils.go
+++ b/pkg/dnsx/utils.go
@@ -112,6 +112,17 @@ func NewRR(name string, qtype uint16, ttl int, value string) dns.RR {
 			},
 			Target: value,
 		}
+
+	case dns.TypeNS:
+		return &dns.NS{
+			Hdr: dns.RR_Header{
+				Name:   name,
+				Rrtype: dns.TypeNS,
+				Class:  dns.ClassINET,
+				Ttl:    uint32(ttl),
+			},
+			Ns: value,
+		}
 	}
 
 	return nil
@@ -147,6 +158,8 @@ func RRToString(rr dns.RR) string {
 		return strings.Join(r.Txt, ",")
 	case *dns.CNAME:
 		return r.Target
+	case *dns.NS:
+		return r.Ns
 	}
 
 	panic("unsupported dns record type")


### PR DESCRIPTION
Now it is possible to add NS records to your payloads:

```sh
sonar dns new -p my -n test -t ns ns1.example.com
```