### PR TITLE
DNS clear cmd

### DIFF
--- a/internal/actions/dns_records.go
+++ b/internal/actions/dns_records.go
@@ -17,12 +17,14 @@ import (
 const (
 	DNSRecordsCreateResultID = "dns-records/create"
 	DNSRecordsDeleteResultID = "dns-records/delete"
+	DNSRecordsClearResultID  = "dns-records/clear"
 	DNSRecordsListResultID   = "dns-records/list"
 )
 
 type DNSActions interface {
 	DNSRecordsCreate(context.Context, DNSRecordsCreateParams) (*DNSRecordsCreateResult, errors.Error)
 	DNSRecordsDelete(context.Context, DNSRecordsDeleteParams) (*DNSRecordsDeleteResult, errors.Error)
+	DNSRecordsClear(context.Context, DNSRecordsClearParams) (DNSRecordsClearResult, errors.Error)
 	DNSRecordsList(context.Context, DNSRecordsListParams) (DNSRecordsListResult, errors.Error)
 }
 
@@ -131,6 +133,40 @@ func DNSRecordsDeleteCommand(p *DNSRecordsDeleteParams, local bool) (*cobra.Comm
 		p.Index = i
 		return nil
 	}
+}
+
+//
+// Clear
+//
+
+type DNSRecordsClearParams struct {
+	PayloadName string `err:"payload" path:"payload" query:"-"`
+	Name        string `err:"name"    query:"name"`
+}
+
+func (p DNSRecordsClearParams) Validate() error {
+	return validation.ValidateStruct(&p,
+		validation.Field(&p.PayloadName, validation.Required),
+	)
+}
+
+type DNSRecordsClearResult []DNSRecord
+
+func (r DNSRecordsClearResult) ResultID() string {
+	return DNSRecordsClearResultID
+}
+
+func DNSRecordsClearCommand(p *DNSRecordsClearParams, local bool) (*cobra.Command, PrepareCommandFunc) {
+	cmd := &cobra.Command{
+		Use:     "clr",
+		Short:   "Delete multiple DNS records",
+		Long:    "Delete multiple DNS records",
+	}
+
+	cmd.Flags().StringVarP(&p.PayloadName, "payload", "p", "", "Payload name")
+	cmd.Flags().StringVarP(&p.Name, "name", "n", "", "Subdomain")
+
+	return cmd, nil
 }
 
 //

--- a/internal/actions/mock/Actions.go
+++ b/internal/actions/mock/Actions.go
@@ -17,6 +17,38 @@ type Actions struct {
 	mock.Mock
 }
 
+// DNSRecordsClear provides a mock function with given fields: _a0, _a1
+func (_m *Actions) DNSRecordsClear(_a0 context.Context, _a1 actions.DNSRecordsClearParams) (actions.DNSRecordsClearResult, errors.Error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DNSRecordsClear")
+	}
+
+	var r0 actions.DNSRecordsClearResult
+	var r1 errors.Error
+	if rf, ok := ret.Get(0).(func(context.Context, actions.DNSRecordsClearParams) (actions.DNSRecordsClearResult, errors.Error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, actions.DNSRecordsClearParams) actions.DNSRecordsClearResult); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(actions.DNSRecordsClearResult)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, actions.DNSRecordsClearParams) errors.Error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.Error)
+		}
+	}
+
+	return r0, r1
+}
+
 // DNSRecordsCreate provides a mock function with given fields: _a0, _a1
 func (_m *Actions) DNSRecordsCreate(_a0 context.Context, _a1 actions.DNSRecordsCreateParams) (*actions.DNSRecordsCreateResult, errors.Error) {
 	ret := _m.Called(_a0, _a1)

--- a/internal/actionsdb/dns_records_test.go
+++ b/internal/actionsdb/dns_records_test.go
@@ -464,3 +464,81 @@ func TestDNSRecordsList_Error(t *testing.T) {
 		})
 	}
 }
+
+func TestDNSRecordsClear_Success(t *testing.T) {
+
+	tests := []struct {
+		name  string
+		p     actions.DNSRecordsClearParams
+		count int
+	}{
+		{
+			"payload1",
+			actions.DNSRecordsClearParams{
+				PayloadName: "payload1",
+			},
+			9,
+		},
+		{
+			"payload4",
+			actions.DNSRecordsClearParams{
+				PayloadName: "payload4",
+			},
+			0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup(t)
+			defer teardown(t)
+
+			u, err := db.UsersGetByID(1)
+			require.NoError(t, err)
+
+			ctx := actionsdb.SetUser(context.Background(), u)
+
+			list, err := acts.DNSRecordsClear(ctx, tt.p)
+			assert.NoError(t, err)
+			assert.Len(t, list, tt.count)
+		})
+	}
+}
+
+func TestDNSRecordsClear_Error(t *testing.T) {
+
+	tests := []struct {
+		name   string
+		userID int
+		p      actions.DNSRecordsClearParams
+		err    error
+	}{
+		{
+			"no user in ctx",
+			0,
+			actions.DNSRecordsClearParams{
+				Name: "test",
+			},
+			&errors.InternalError{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup(t)
+			defer teardown(t)
+
+			ctx := context.Background()
+			if tt.userID != 0 {
+				u, err := db.UsersGetByID(1)
+				require.NoError(t, err)
+
+				ctx = actionsdb.SetUser(context.Background(), u)
+			}
+
+			_, err := acts.DNSRecordsClear(ctx, tt.p)
+			assert.Error(t, err)
+			assert.IsType(t, tt.err, err)
+		})
+	}
+}

--- a/internal/actionsdb/dns_records_test.go
+++ b/internal/actionsdb/dns_records_test.go
@@ -480,6 +480,14 @@ func TestDNSRecordsClear_Success(t *testing.T) {
 			9,
 		},
 		{
+			"payload1",
+			actions.DNSRecordsClearParams{
+				PayloadName: "payload1",
+				Name:        "test-a",
+			},
+			1,
+		},
+		{
 			"payload4",
 			actions.DNSRecordsClearParams{
 				PayloadName: "payload4",
@@ -520,6 +528,14 @@ func TestDNSRecordsClear_Error(t *testing.T) {
 				Name: "test",
 			},
 			&errors.InternalError{},
+		},
+		{
+			"not existing payload",
+			1,
+			actions.DNSRecordsClearParams{
+				PayloadName: "not-exist",
+			},
+			&errors.NotFoundError{},
 		},
 	}
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -65,6 +65,7 @@ func (c *Command) root(onResult func(actions.Result) error) *cobra.Command {
 	dns.AddCommand(c.withAuthCheck(c.DNSRecordsCreate(onResult)))
 	dns.AddCommand(c.withAuthCheck(c.DNSRecordsDelete(onResult)))
 	dns.AddCommand(c.withAuthCheck(c.DNSRecordsList(onResult)))
+	dns.AddCommand(c.withAuthCheck(c.DNSRecordsClear(onResult)))
 
 	root.AddCommand(dns)
 

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -190,6 +190,18 @@ func TestCmd(t *testing.T) {
 			&actions.DNSRecordsDeleteResult{},
 		},
 
+		// Clear
+
+		{
+			"dns clr -p payload1 -n test",
+			"DNSRecordsClear",
+			actions.DNSRecordsClearParams{
+				PayloadName: "payload1",
+				Name: "test",
+			},
+			actions.DNSRecordsClearResult{},
+		},
+
 		//
 		// Users
 		//

--- a/internal/cmd/generated.go
+++ b/internal/cmd/generated.go
@@ -6,6 +6,33 @@ import (
 	"github.com/russtone/sonar/internal/actions"
 )
 
+func (c *Command) DNSRecordsClear(onResult func(actions.Result) error) *cobra.Command {
+	var params actions.DNSRecordsClearParams
+
+	cmd, prepareFunc := actions.DNSRecordsClearCommand(&params, c.options.allowFileAccess)
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if prepareFunc != nil {
+			if err := prepareFunc(cmd, args); err != nil {
+				return err
+			}
+		}
+
+		if err := params.Validate(); err != nil {
+			return err
+		}
+
+		res, err := c.actions.DNSRecordsClear(cmd.Context(), params)
+		if err != nil {
+			return err
+		}
+
+		return onResult(res)
+	}
+
+	return cmd
+}
+
 func (c *Command) DNSRecordsCreate(onResult func(actions.Result) error) *cobra.Command {
 	var params actions.DNSRecordsCreateParams
 

--- a/internal/database/dns_records.go
+++ b/internal/database/dns_records.go
@@ -88,3 +88,25 @@ func (db *DB) DNSRecordsGetByPayloadIDAndIndex(payloadID int64, index int64) (*m
 func (db *DB) DNSRecordsDelete(id int64) error {
 	return db.Exec("DELETE FROM dns_records WHERE id = $1", id)
 }
+
+func (db *DB) DNSRecordsDeleteAllByPayloadID(payloadID int64) ([]*models.DNSRecord, error) {
+	res := make([]*models.DNSRecord, 0)
+
+	if err := db.Select(&res,
+		"DELETE FROM dns_records WHERE payload_id = $1 RETURNING *", payloadID); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (db *DB) DNSRecordsDeleteAllByPayloadIDAndName(payloadID int64, name string) ([]*models.DNSRecord, error) {
+	res := make([]*models.DNSRecord, 0)
+
+	if err := db.Select(&res,
+		"DELETE FROM dns_records WHERE payload_id = $1 AND name = $2 RETURNING *", payloadID, name); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/internal/database/dns_records_test.go
+++ b/internal/database/dns_records_test.go
@@ -149,3 +149,21 @@ func TestDNSRecordsGetByPayloadIDAndIndex(t *testing.T) {
 	_, err = db.DNSRecordsGetByPayloadIDAndIndex(1, 1337)
 	assert.Error(t, err)
 }
+
+func TestDNSRecordsDeleteAllByPayloadID(t *testing.T) {
+	setup(t)
+	defer teardown(t)
+
+	l, err := db.DNSRecordsDeleteAllByPayloadID(1)
+	assert.NoError(t, err)
+	assert.Len(t, l, 9)
+}
+
+func TestDNSRecordsDeleteAllByPayloadIDAndName(t *testing.T) {
+	setup(t)
+	defer teardown(t)
+
+	l, err := db.DNSRecordsDeleteAllByPayloadIDAndName(1, "test-a")
+	assert.NoError(t, err)
+	assert.Len(t, l, 1)
+}

--- a/internal/modules/api/api.go
+++ b/internal/modules/api/api.go
@@ -64,6 +64,7 @@ func (api *API) Router() http.Handler {
 		r.Post("/", api.DNSRecordsCreate)
 		r.Route("/{payload}", func(r chi.Router) {
 			r.Get("/", api.DNSRecordsList)
+			r.Delete("/", api.DNSRecordsClear)
 			r.Route("/{index}", func(r chi.Router) {
 				r.Delete("/", api.DNSRecordsDelete)
 			})

--- a/internal/modules/api/api_test.go
+++ b/internal/modules/api/api_test.go
@@ -474,6 +474,30 @@ func TestAPI(t *testing.T) {
 			status: 404,
 		},
 
+		// Clear
+
+		{
+			method: "DELETE",
+			path:   "/dns-records/payload1/",
+			token:  User1Token,
+			schema: actions.DNSRecordsClearResult{},
+			status: 200,
+			result: map[string]matcher{
+				"$[0].name": equal("test-a"),
+				"$[1].name": equal("test-aaaa"),
+			},
+		},
+		{
+			method: "DELETE",
+			path:   "/dns-records/not-exist/",
+			token:  User1Token,
+			schema: &errors.NotFoundError{},
+			result: map[string]matcher{
+				"$.message": contains("not found"),
+			},
+			status: 404,
+		},
+
 		//
 		// User
 		//

--- a/internal/modules/api/apiclient/client_test.go
+++ b/internal/modules/api/apiclient/client_test.go
@@ -355,6 +355,19 @@ func TestClient(t *testing.T) {
 			nil,
 		},
 
+		// Clear
+
+		{
+			actions.DNSRecordsClearParams{
+				PayloadName: "payload1",
+			},
+			map[string]matcher{
+				"0.Name": equal("test-a"),
+				"8.Name": equal("test-rebind"),
+			},
+			nil,
+		},
+
 		//
 		// Users
 		//
@@ -508,6 +521,8 @@ func TestClient(t *testing.T) {
 				res, err = uc.DNSRecordsList(context.Background(), p)
 			case actions.DNSRecordsDeleteParams:
 				res, err = uc.DNSRecordsDelete(context.Background(), p)
+			case actions.DNSRecordsClearParams:
+				res, err = uc.DNSRecordsClear(context.Background(), p)
 
 			// Events
 			case actions.EventsListParams:

--- a/internal/modules/api/apiclient/generated.go
+++ b/internal/modules/api/apiclient/generated.go
@@ -7,6 +7,24 @@ import (
 	"github.com/russtone/sonar/internal/utils/errors"
 )
 
+func (c *Client) DNSRecordsClear(ctx context.Context, params actions.DNSRecordsClearParams) (actions.DNSRecordsClearResult, errors.Error) {
+	var res actions.DNSRecordsClearResult
+
+	err := handle(c.client.R().
+		SetPathParams(toPath(params)).
+		SetQueryParamsFromValues(toQuery(params)).
+		SetError(&APIError{}).
+		SetResult(&res).
+		SetContext(ctx).
+		Delete("/dns-records/{payload}"))
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
 func (c *Client) DNSRecordsCreate(ctx context.Context, params actions.DNSRecordsCreateParams) (*actions.DNSRecordsCreateResult, errors.Error) {
 	var res *actions.DNSRecordsCreateResult
 
@@ -79,8 +97,8 @@ func (c *Client) EventsList(ctx context.Context, params actions.EventsListParams
 	var res actions.EventsListResult
 
 	err := handle(c.client.R().
-		SetPathParams(toPath(params)).
 		SetQueryParamsFromValues(toQuery(params)).
+		SetPathParams(toPath(params)).
 		SetError(&APIError{}).
 		SetResult(&res).
 		SetContext(ctx).

--- a/internal/modules/api/generated.go
+++ b/internal/modules/api/generated.go
@@ -6,6 +6,29 @@ import (
 	"github.com/russtone/sonar/internal/actions"
 )
 
+func (api *API) DNSRecordsClear(w http.ResponseWriter, r *http.Request) {
+
+	var params actions.DNSRecordsClearParams
+
+	if err := fromPath(r, &params); err != nil {
+		api.handleError(w, r, err)
+		return
+	}
+
+	if err := fromQuery(r, &params); err != nil {
+		api.handleError(w, r, err)
+		return
+	}
+
+	res, err := api.actions.DNSRecordsClear(r.Context(), params)
+	if err != nil {
+		api.handleError(w, r, err)
+		return
+	}
+
+	responseJSON(w, res, http.StatusOK)
+}
+
 func (api *API) DNSRecordsCreate(w http.ResponseWriter, r *http.Request) {
 
 	var params actions.DNSRecordsCreateParams

--- a/internal/templates/content.go
+++ b/internal/templates/content.go
@@ -7,22 +7,28 @@ import (
 )
 
 var templatesMap = map[string]string{
-	NotificationHeaderID:             notificationHeader,
-	NotificationBodyID:               notificationBody,
-	actions.ProfileGetResultID:       profileGet,
-	actions.PayloadsListResultID:     payloadsList,
-	actions.PayloadsCreateResultID:   payloadsCreate,
-	actions.PayloadsUpdateResultID:   payloadsUpdate,
-	actions.PayloadsDeleteResultID:   payloadsDelete,
-	actions.PayloadsClearResultID:    payloadsClear,
+	NotificationHeaderID: notificationHeader,
+	NotificationBodyID:   notificationBody,
+
+	actions.ProfileGetResultID: profileGet,
+
+	actions.PayloadsListResultID:   payloadsList,
+	actions.PayloadsCreateResultID: payloadsCreate,
+	actions.PayloadsUpdateResultID: payloadsUpdate,
+	actions.PayloadsDeleteResultID: payloadsDelete,
+	actions.PayloadsClearResultID:  payloadsClear,
+
 	actions.DNSRecordsListResultID:   dnsRecordsList,
 	actions.DNSRecordsCreateResultID: dnsRecordsCreate,
 	actions.DNSRecordsDeleteResultID: dnsRecordsDelete,
+	actions.DNSRecordsClearResultID: dnsRecordsClear,
+
 	actions.HTTPRoutesListResultID:   httpRoutesList,
 	actions.HTTPRoutesCreateResultID: httpRoutesCreate,
 	actions.HTTPRoutesDeleteResultID: httpRoutesDelete,
-	actions.EventsListResultID:       eventsList,
-	actions.EventsGetResultID:        eventsGet,
+
+	actions.EventsListResultID: eventsList,
+	actions.EventsGetResultID:  eventsGet,
 }
 
 //
@@ -68,6 +74,7 @@ var dnsRecordsList = fmt.Sprintf(`
 {{ else }}nothing found{{ end }}`, dnsRecord)
 var dnsRecordsCreate = dnsRecord
 var dnsRecordsDelete = `dns record deleted`
+var dnsRecordsClear = `{{ len . }} dns records deleted`
 
 //
 // HTTP routes


### PR DESCRIPTION
Added new `clr` command for DNS records:
```
$ sonar help dns clr
Delete multiple DNS records

Usage:
  sonar dns clr [flags]

Flags:
  -h, --help             help for clr
      --json             JSON output
  -n, --name string      Subdomain
  -p, --payload string   Payload name

```