### PR TITLE
HTTP routes clear command

### DIFF
--- a/internal/actions/http_routes.go
+++ b/internal/actions/http_routes.go
@@ -21,12 +21,14 @@ import (
 const (
 	HTTPRoutesCreateResultID = "http-routes/create"
 	HTTPRoutesDeleteResultID = "http-routes/delete"
+	HTTPRoutesClearResultID  = "http-routes/clear"
 	HTTPRoutesListResultID   = "http-routes/list"
 )
 
 type HTTPActions interface {
 	HTTPRoutesCreate(context.Context, HTTPRoutesCreateParams) (*HTTPRoutesCreateResult, errors.Error)
 	HTTPRoutesDelete(context.Context, HTTPRoutesDeleteParams) (*HTTPRoutesDeleteResult, errors.Error)
+	HTTPRoutesClear(context.Context, HTTPRoutesClearParams) (HTTPRoutesClearResult, errors.Error)
 	HTTPRoutesList(context.Context, HTTPRoutesListParams) (HTTPRoutesListResult, errors.Error)
 }
 
@@ -180,6 +182,39 @@ func HTTPRoutesDeleteCommand(p *HTTPRoutesDeleteParams, local bool) (*cobra.Comm
 		p.Index = i
 		return nil
 	}
+}
+
+//
+// Clear
+//
+
+type HTTPRoutesClearParams struct {
+	PayloadName string `err:"payload" path:"payload"`
+	Path        string `err:"path"    query:"path"`
+}
+
+func (p HTTPRoutesClearParams) Validate() error {
+	return validation.ValidateStruct(&p,
+		validation.Field(&p.PayloadName, validation.Required),
+	)
+}
+
+type HTTPRoutesClearResult []HTTPRoute
+
+func (r HTTPRoutesClearResult) ResultID() string {
+	return HTTPRoutesClearResultID
+}
+
+func HTTPRoutesClearCommand(p *HTTPRoutesClearParams, local bool) (*cobra.Command, PrepareCommandFunc) {
+	cmd := &cobra.Command{
+		Use:   "clr",
+		Short: "Delete multiple HTTP routes",
+	}
+
+	cmd.Flags().StringVarP(&p.PayloadName, "payload", "p", "", "Payload name")
+	cmd.Flags().StringVarP(&p.Path, "path", "P", "", "Path")
+
+	return cmd, nil
 }
 
 //

--- a/internal/actions/mock/Actions.go
+++ b/internal/actions/mock/Actions.go
@@ -209,6 +209,38 @@ func (_m *Actions) EventsList(_a0 context.Context, _a1 actions.EventsListParams)
 	return r0, r1
 }
 
+// HTTPRoutesClear provides a mock function with given fields: _a0, _a1
+func (_m *Actions) HTTPRoutesClear(_a0 context.Context, _a1 actions.HTTPRoutesClearParams) (actions.HTTPRoutesClearResult, errors.Error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HTTPRoutesClear")
+	}
+
+	var r0 actions.HTTPRoutesClearResult
+	var r1 errors.Error
+	if rf, ok := ret.Get(0).(func(context.Context, actions.HTTPRoutesClearParams) (actions.HTTPRoutesClearResult, errors.Error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, actions.HTTPRoutesClearParams) actions.HTTPRoutesClearResult); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(actions.HTTPRoutesClearResult)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, actions.HTTPRoutesClearParams) errors.Error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.Error)
+		}
+	}
+
+	return r0, r1
+}
+
 // HTTPRoutesCreate provides a mock function with given fields: _a0, _a1
 func (_m *Actions) HTTPRoutesCreate(_a0 context.Context, _a1 actions.HTTPRoutesCreateParams) (*actions.HTTPRoutesCreateResult, errors.Error) {
 	ret := _m.Called(_a0, _a1)

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -89,6 +89,7 @@ func (c *Command) root(onResult func(actions.Result) error) *cobra.Command {
 	http.AddCommand(c.withAuthCheck(c.HTTPRoutesCreate(onResult)))
 	http.AddCommand(c.withAuthCheck(c.HTTPRoutesDelete(onResult)))
 	http.AddCommand(c.withAuthCheck(c.HTTPRoutesList(onResult)))
+	http.AddCommand(c.withAuthCheck(c.HTTPRoutesClear(onResult)))
 
 	root.AddCommand(http)
 

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -197,7 +197,7 @@ func TestCmd(t *testing.T) {
 			"DNSRecordsClear",
 			actions.DNSRecordsClearParams{
 				PayloadName: "payload1",
-				Name: "test",
+				Name:        "test",
 			},
 			actions.DNSRecordsClearResult{},
 		},
@@ -328,6 +328,18 @@ func TestCmd(t *testing.T) {
 				Index:       1,
 			},
 			&actions.HTTPRoutesDeleteResult{},
+		},
+
+		// Clear
+
+		{
+			"http clr -p payload1 -P /test",
+			"HTTPRoutesClear",
+			actions.HTTPRoutesClearParams{
+				PayloadName: "payload1",
+				Path:        "/test",
+			},
+			actions.HTTPRoutesClearResult{},
 		},
 	}
 

--- a/internal/cmd/generated.go
+++ b/internal/cmd/generated.go
@@ -168,6 +168,33 @@ func (c *Command) EventsList(onResult func(actions.Result) error) *cobra.Command
 	return cmd
 }
 
+func (c *Command) HTTPRoutesClear(onResult func(actions.Result) error) *cobra.Command {
+	var params actions.HTTPRoutesClearParams
+
+	cmd, prepareFunc := actions.HTTPRoutesClearCommand(&params, c.options.allowFileAccess)
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if prepareFunc != nil {
+			if err := prepareFunc(cmd, args); err != nil {
+				return err
+			}
+		}
+
+		if err := params.Validate(); err != nil {
+			return err
+		}
+
+		res, err := c.actions.HTTPRoutesClear(cmd.Context(), params)
+		if err != nil {
+			return err
+		}
+
+		return onResult(res)
+	}
+
+	return cmd
+}
+
 func (c *Command) HTTPRoutesCreate(onResult func(actions.Result) error) *cobra.Command {
 	var params actions.HTTPRoutesCreateParams
 

--- a/internal/database/http_routes.go
+++ b/internal/database/http_routes.go
@@ -81,3 +81,25 @@ func (db *DB) HTTPRoutesGetByPayloadIDAndIndex(payloadID int64, index int64) (*m
 func (db *DB) HTTPRoutesDelete(id int64) error {
 	return db.Exec("DELETE FROM http_routes WHERE id = $1", id)
 }
+
+func (db *DB) HTTPRoutesDeleteAllByPayloadID(payloadID int64) ([]*models.HTTPRoute, error) {
+	res := make([]*models.HTTPRoute, 0)
+
+	if err := db.Select(&res,
+		"DELETE FROM http_routes WHERE payload_id = $1 RETURNING *", payloadID); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (db *DB) HTTPRoutesDeleteAllByPayloadIDAndPath(payloadID int64, path string) ([]*models.HTTPRoute, error) {
+	res := make([]*models.HTTPRoute, 0)
+
+	if err := db.Select(&res,
+		"DELETE FROM http_routes WHERE payload_id = $1 AND path = $2 RETURNING *", payloadID, path); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/internal/database/http_routes_test.go
+++ b/internal/database/http_routes_test.go
@@ -134,3 +134,21 @@ func TestHTTPRoutesGetByPayloadMethodAndPath(t *testing.T) {
 	_, err = db.HTTPRoutesGetByPayloadMethodAndPath(1337, "POST", "/post")
 	assert.Error(t, err)
 }
+
+func TestHTTPRoutesDeleteAllByPayloadID(t *testing.T) {
+	setup(t)
+	defer teardown(t)
+
+	l, err := db.HTTPRoutesDeleteAllByPayloadID(1)
+	assert.NoError(t, err)
+	assert.Len(t, l, 5)
+}
+
+func TestHTTPRoutesDeleteAllByPayloadIDAndName(t *testing.T) {
+	setup(t)
+	defer teardown(t)
+
+	l, err := db.HTTPRoutesDeleteAllByPayloadIDAndPath(1, "/get")
+	assert.NoError(t, err)
+	assert.Len(t, l, 1)
+}

--- a/internal/modules/api/api.go
+++ b/internal/modules/api/api.go
@@ -75,6 +75,7 @@ func (api *API) Router() http.Handler {
 		r.Post("/", api.HTTPRoutesCreate)
 		r.Route("/{payload}", func(r chi.Router) {
 			r.Get("/", api.HTTPRoutesList)
+			r.Delete("/", api.HTTPRoutesClear)
 			r.Route("/{index}", func(r chi.Router) {
 				r.Delete("/", api.HTTPRoutesDelete)
 			})

--- a/internal/modules/api/api_test.go
+++ b/internal/modules/api/api_test.go
@@ -762,6 +762,30 @@ func TestAPI(t *testing.T) {
 			},
 			status: 404,
 		},
+
+		// Clear
+
+		{
+			method: "DELETE",
+			path:   "/http-routes/payload1/",
+			token:  User1Token,
+			schema: actions.HTTPRoutesClearResult{},
+			status: 200,
+			result: map[string]matcher{
+				"$[0].path": equal("/get"),
+				"$[1].path": equal("/post"),
+			},
+		},
+		{
+			method: "DELETE",
+			path:   "/http-routes/not-exist/",
+			token:  User1Token,
+			schema: &errors.NotFoundError{},
+			result: map[string]matcher{
+				"$.message": contains("not found"),
+			},
+			status: 404,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/modules/api/apiclient/client_test.go
+++ b/internal/modules/api/apiclient/client_test.go
@@ -488,6 +488,19 @@ func TestClient(t *testing.T) {
 			},
 			nil,
 		},
+
+		// Clear
+
+		{
+			actions.HTTPRoutesClearParams{
+				PayloadName: "payload1",
+			},
+			map[string]matcher{
+				"0.Path": equal("/get"),
+				"4.Path": equal("/route/{test}"),
+			},
+			nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -543,6 +556,8 @@ func TestClient(t *testing.T) {
 				res, err = uc.HTTPRoutesList(context.Background(), p)
 			case actions.HTTPRoutesDeleteParams:
 				res, err = uc.HTTPRoutesDelete(context.Background(), p)
+			case actions.HTTPRoutesClearParams:
+				res, err = uc.HTTPRoutesClear(context.Background(), p)
 
 			// Profile
 			case nil:

--- a/internal/modules/api/apiclient/generated.go
+++ b/internal/modules/api/apiclient/generated.go
@@ -11,8 +11,8 @@ func (c *Client) DNSRecordsClear(ctx context.Context, params actions.DNSRecordsC
 	var res actions.DNSRecordsClearResult
 
 	err := handle(c.client.R().
-		SetPathParams(toPath(params)).
 		SetQueryParamsFromValues(toQuery(params)).
+		SetPathParams(toPath(params)).
 		SetError(&APIError{}).
 		SetResult(&res).
 		SetContext(ctx).
@@ -97,12 +97,30 @@ func (c *Client) EventsList(ctx context.Context, params actions.EventsListParams
 	var res actions.EventsListResult
 
 	err := handle(c.client.R().
-		SetQueryParamsFromValues(toQuery(params)).
 		SetPathParams(toPath(params)).
+		SetQueryParamsFromValues(toQuery(params)).
 		SetError(&APIError{}).
 		SetResult(&res).
 		SetContext(ctx).
 		Get("/events/{payload}"))
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (c *Client) HTTPRoutesClear(ctx context.Context, params actions.HTTPRoutesClearParams) (actions.HTTPRoutesClearResult, errors.Error) {
+	var res actions.HTTPRoutesClearResult
+
+	err := handle(c.client.R().
+		SetPathParams(toPath(params)).
+		SetQueryParamsFromValues(toQuery(params)).
+		SetError(&APIError{}).
+		SetResult(&res).
+		SetContext(ctx).
+		Delete("/http-routes/{payload}"))
 
 	if err != nil {
 		return nil, err

--- a/internal/modules/api/generated.go
+++ b/internal/modules/api/generated.go
@@ -10,12 +10,12 @@ func (api *API) DNSRecordsClear(w http.ResponseWriter, r *http.Request) {
 
 	var params actions.DNSRecordsClearParams
 
-	if err := fromPath(r, &params); err != nil {
+	if err := fromQuery(r, &params); err != nil {
 		api.handleError(w, r, err)
 		return
 	}
 
-	if err := fromQuery(r, &params); err != nil {
+	if err := fromPath(r, &params); err != nil {
 		api.handleError(w, r, err)
 		return
 	}
@@ -116,6 +116,29 @@ func (api *API) EventsList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res, err := api.actions.EventsList(r.Context(), params)
+	if err != nil {
+		api.handleError(w, r, err)
+		return
+	}
+
+	responseJSON(w, res, http.StatusOK)
+}
+
+func (api *API) HTTPRoutesClear(w http.ResponseWriter, r *http.Request) {
+
+	var params actions.HTTPRoutesClearParams
+
+	if err := fromPath(r, &params); err != nil {
+		api.handleError(w, r, err)
+		return
+	}
+
+	if err := fromQuery(r, &params); err != nil {
+		api.handleError(w, r, err)
+		return
+	}
+
+	res, err := api.actions.HTTPRoutesClear(r.Context(), params)
 	if err != nil {
 		api.handleError(w, r, err)
 		return

--- a/internal/templates/content.go
+++ b/internal/templates/content.go
@@ -26,6 +26,7 @@ var templatesMap = map[string]string{
 	actions.HTTPRoutesListResultID:   httpRoutesList,
 	actions.HTTPRoutesCreateResultID: httpRoutesCreate,
 	actions.HTTPRoutesDeleteResultID: httpRoutesDelete,
+	actions.HTTPRoutesClearResultID: httpRoutesClear,
 
 	actions.EventsListResultID: eventsList,
 	actions.EventsGetResultID:  eventsGet,
@@ -90,6 +91,7 @@ var httpRoutesList = fmt.Sprintf(`
 {{ else }}nothing found{{ end }}`, httpRoute)
 var httpRoutesCreate = httpRoute
 var httpRoutesDelete = "http route deleted"
+var httpRoutesClear = `{{ len . }} http routes deleted`
 
 //
 // Users


### PR DESCRIPTION
```
$ sonar http clr

Delete multiple HTTP routes

Usage:
  sonar http clr [flags]

Flags:
  -h, --help             help for clr
      --json             JSON output
  -P, --path string      Path
  -p, --payload string   Payload name

Global Flags:
      --config string   config file

```