### PR TITLE
Fix concurrent events creation

### DIFF
--- a/internal/actionsdb/events_test.go
+++ b/internal/actionsdb/events_test.go
@@ -30,8 +30,8 @@ func TestEventsList_Success(t *testing.T) {
 				PayloadName: "payload1",
 				Count:       10,
 			},
-			9,
-			9, 1,
+			10,
+			10, 1,
 		},
 		{
 			"count",
@@ -40,7 +40,7 @@ func TestEventsList_Success(t *testing.T) {
 				Count:       5,
 			},
 			5,
-			9, 5,
+			10, 6,
 		},
 		{
 			"after",

--- a/internal/cmd/server/events.go
+++ b/internal/cmd/server/events.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"database/sql"
+	"fmt"
 	"net"
 	"regexp"
 	"strings"
@@ -86,11 +86,7 @@ func (h *EventsHandler) worker(id int) {
 			// Store event in database
 			if p.StoreEvents {
 				if err := h.db.EventsCreate(e); err != nil {
-					continue
-				}
-
-				// Delete out of limit events
-				if err := h.db.EventsDeleteOutOfLimit(p.ID, 1000 /* TODO: from config */); err != nil && err != sql.ErrNoRows {
+					fmt.Println(err)
 					continue
 				}
 			}

--- a/internal/database/db_helper.go
+++ b/internal/database/db_helper.go
@@ -30,17 +30,13 @@ func (db *DB) QueryRowx(query string, args ...interface{}) *row {
 
 func (db *DB) Exec(query string, args ...interface{}) error {
 	db.logQuery(query, args...)
-	res, err := db.DB.Exec(query, args...)
-	if err != nil {
-		return err
-	}
-
-	if n, err := res.RowsAffected(); err != nil {
-		return err
-	} else if n == 0 {
-		return sql.ErrNoRows
-	}
+	_, err := db.DB.Exec(query, args...)
 	return err
+}
+
+func (db *DB) ExecResult(query string, args ...interface{}) (sql.Result, error) {
+	db.logQuery(query, args...)
+	return db.DB.Exec(query, args...)
 }
 
 func (db *DB) Get(dest interface{}, query string, args ...interface{}) error {

--- a/internal/database/events_test.go
+++ b/internal/database/events_test.go
@@ -68,8 +68,8 @@ func TestEventsListByPayloadID_Success(t *testing.T) {
 	// Default
 	l, err := db.EventsListByPayloadID(1)
 	assert.NoError(t, err)
-	require.Len(t, l, 9)
-	assert.EqualValues(t, l[0].ID, 9)
+	require.Len(t, l, 10)
+	assert.EqualValues(t, l[0].ID, 11)
 	assert.EqualValues(t, l[len(l)-1].ID, 1)
 
 	l, err = db.EventsListByPayloadID(1,
@@ -81,8 +81,8 @@ func TestEventsListByPayloadID_Success(t *testing.T) {
 	// Count
 	assert.NoError(t, err)
 	require.Len(t, l, 3)
-	assert.EqualValues(t, l[0].ID, 9)
-	assert.EqualValues(t, l[len(l)-1].ID, 7)
+	assert.EqualValues(t, l[0].ID, 11)
+	assert.EqualValues(t, l[len(l)-1].ID, 8)
 
 	// Before
 	l, err = db.EventsListByPayloadID(1,
@@ -104,8 +104,8 @@ func TestEventsListByPayloadID_Success(t *testing.T) {
 		}),
 	)
 	assert.NoError(t, err)
-	require.Len(t, l, 2)
-	assert.EqualValues(t, l[0].ID, 9)
+	require.Len(t, l, 3)
+	assert.EqualValues(t, l[0].ID, 11)
 	assert.EqualValues(t, l[len(l)-1].ID, 8)
 
 	// Reverse
@@ -117,9 +117,9 @@ func TestEventsListByPayloadID_Success(t *testing.T) {
 		database.EventsReverse(true),
 	)
 	assert.NoError(t, err)
-	require.Len(t, l, 2)
+	require.Len(t, l, 3)
 	assert.EqualValues(t, l[0].ID, 8)
-	assert.EqualValues(t, l[len(l)-1].ID, 9)
+	assert.EqualValues(t, l[len(l)-1].ID, 11)
 }
 
 func TestEventsGetByPayloadAndIndex_Success(t *testing.T) {
@@ -132,22 +132,6 @@ func TestEventsGetByPayloadAndIndex_Success(t *testing.T) {
 
 	o, err = db.EventsGetByPayloadAndIndex(1, 1337)
 	assert.Error(t, err)
-}
-
-func TestEventsDeleteOutOfLimit(t *testing.T) {
-	setup(t)
-	defer teardown(t)
-
-	err := db.EventsDeleteOutOfLimit(1, 5)
-	assert.NoError(t, err)
-
-	var list []*models.Event
-	list, err = db.EventsListByPayloadID(1)
-	assert.NoError(t, err)
-	assert.Len(t, list, 5)
-
-	err = db.EventsDeleteOutOfLimit(2, 5)
-	assert.ErrorIs(t, err, sql.ErrNoRows)
 }
 
 func TestEventsRace(t *testing.T) {

--- a/internal/database/fixtures/events.yml
+++ b/internal/database/fixtures/events.yml
@@ -1,6 +1,5 @@
 - id: 1
   payload_id: 1
-  index: 1
   protocol: dns
   r: read
   w: written
@@ -13,7 +12,6 @@
 
 - id: 2
   payload_id: 1
-  index: 2
   protocol: http
   r: read
   w: written
@@ -26,7 +24,6 @@
 
 - id: 3
   payload_id: 1
-  index: 3
   protocol: http
   r: read
   w: written
@@ -39,7 +36,6 @@
 
 - id: 4
   payload_id: 1
-  index: 4
   protocol: http
   r: read
   w: written
@@ -52,7 +48,6 @@
 
 - id: 5
   payload_id: 1
-  index: 5
   protocol: http
   r: read
   w: written
@@ -65,7 +60,6 @@
 
 - id: 6
   payload_id: 1
-  index: 6
   protocol: http
   r: read
   w: written
@@ -78,7 +72,6 @@
 
 - id: 7
   payload_id: 1
-  index: 7
   protocol: http
   r: read
   w: written
@@ -91,7 +84,6 @@
 
 - id: 8
   payload_id: 1
-  index: 8
   protocol: http
   r: read
   w: written
@@ -104,7 +96,30 @@
 
 - id: 9
   payload_id: 1
-  index: 9
+  protocol: http
+  r: read
+  w: written
+  rw: read-and-written
+  meta:
+    key: value
+  remote_addr: 127.0.0.1:1337
+  received_at: RAW=NOW() AT TIME ZONE 'UTC'
+  created_at: RAW=NOW() AT TIME ZONE 'UTC'
+
+- id: 10
+  payload_id: 2
+  protocol: http
+  r: read
+  w: written
+  rw: read-and-written
+  meta:
+    key: value
+  remote_addr: 127.0.0.1:1337
+  received_at: RAW=NOW() AT TIME ZONE 'UTC'
+  created_at: RAW=NOW() AT TIME ZONE 'UTC'
+
+- id: 11
+  payload_id: 1
   protocol: http
   r: read
   w: written

--- a/internal/database/migrations/000020_events_drop_index_column.down.sql
+++ b/internal/database/migrations/000020_events_drop_index_column.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE events ADD COLUMN index INT NOT NULL DEFAULT 0;
+UPDATE events e SET index = (SELECT index FROM (SELECT id, ROW_NUMBER() OVER(PARTITION BY payload_id ORDER BY id ASC) AS index FROM events) q WHERE q.id = e.id);
+ALTER TABLE events ADD UNIQUE (payload_id, index);

--- a/internal/database/migrations/000020_events_drop_index_column.up.sql
+++ b/internal/database/migrations/000020_events_drop_index_column.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events DROP COLUMN index;

--- a/internal/modules/api/api_test.go
+++ b/internal/modules/api/api_test.go
@@ -619,9 +619,9 @@ func TestAPI(t *testing.T) {
 			token:  User1Token,
 			schema: (actions.EventsListResult)(nil),
 			result: map[string]matcher{
-				"$":             length(9),
+				"$":             length(10),
 				"$[0].protocol": equal("http"),
-				"$[8].protocol": equal("dns"),
+				"$[9].protocol": equal("dns"),
 			},
 			status: 200,
 		},

--- a/internal/modules/api/apiclient/client_test.go
+++ b/internal/modules/api/apiclient/client_test.go
@@ -417,7 +417,7 @@ func TestClient(t *testing.T) {
 			},
 			map[string]matcher{
 				"0.Protocol": equal("http"),
-				"8.Protocol": equal("dns"),
+				"9.Protocol": equal("dns"),
 			},
 			nil,
 		},


### PR DESCRIPTION
- removed the "index" column from the "events" table
- changed index to `ROW_NUMBER()` instead
- events limit is removed currently, because it will mess up ROW_NUMBER()